### PR TITLE
point linux_amd64 to correct image

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -76,7 +76,7 @@ function install {
 		FTYPE=".tar.gz"
 		;;
 	"linux_amd64")
-		URL="https://github.com/txlabs/blockless-cli/releases/download/${VERSION}/bls-linux-arm64-blockless-cli.tar.gz"
+		URL="https://github.com/txlabs/blockless-cli/releases/download/${VERSION}/bls-linux-x64-blockless-cli.tar.gz"
 		FTYPE=".tar.gz"
 		;;
 	"linux_arm64")


### PR DESCRIPTION
This patch updates the link for `linux_amd64` architecture to `bls-linux-x64-blockless-cli`.