### PR TITLE
add function init feature to bls command line

### DIFF
--- a/src/commands/function/init.ts
+++ b/src/commands/function/init.ts
@@ -1,0 +1,24 @@
+import Chalk from "chalk";
+import { execSync } from "child_process";
+
+const sanitizer = /[^a-zA-Z0-9]/;
+
+const sanitize = (input: string) => input.replace(sanitizer, "");
+
+export const run = (options: any) => {
+  const { name, path } = options;
+  const installationPath = `/${sanitize(path)}/${sanitize(name)}`;
+
+  console.log(Chalk.yellow(`Initializing new function in ${installationPath}`));
+  execSync(
+    `mkdir -p ${installationPath}; cd ${installationPath}; npm init @blockless/app`,
+    {
+      stdio: "inherit",
+    }
+  );
+  console.log(
+    Chalk.green(
+      `Initialization of function ${installationPath} completed successfully`
+    ) // because I said so in the absence of actual verification :D
+  );
+};

--- a/src/commands/function/init.ts
+++ b/src/commands/function/init.ts
@@ -1,7 +1,7 @@
 import Chalk from "chalk";
 import { execSync } from "child_process";
 
-const sanitizer = /[^a-zA-Z0-9]/;
+const sanitizer = /[^a-zA-Z0-9\-]/;
 
 const sanitize = (input: string) => input.replace(sanitizer, "");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { store, set as storeSet } from "./store";
 import * as wallet from "./methods/wallet";
 import { run as runInstall } from "./commands/offchain/install";
 import { run as runStart } from "./commands/offchain/start";
+import { run as runInit } from "./commands/function/init";
 import pkg from "../package.json";
 
 let didRun = false;
@@ -30,6 +31,14 @@ function printHelp(commands: any, options: any = []) {
 }
 
 args
+  .options([
+    {
+      name: "path",
+      description: "The target path for the command",
+      defaultValue: `${store.system.homedir}/.bls`,
+    },
+    { name: "name", description: "The target name for the command" },
+  ])
   .command(
     "offchain",
     "Interact with local off-chain network [install, start, configure]",
@@ -109,10 +118,34 @@ args
   .command(
     "function",
     "Interact with Functions [init, invoke, delete, list]",
-    (name: string, sub: string[]) => {
+    (name: string, sub: string[], options) => {
       didRun = true;
+
+      if (!sub[0] || sub[0] === "help" || !("name" in options)) {
+        printHelp(
+          [["init", "initialize a new function with @blockless/app"]],
+          [
+            ["-n, --name", "the name of the function to initialize (required)"],
+            [
+              "-p, --path",
+              `the location to initialize the function (optional; defaults to  ${store.system.homedir}/.bls)`,
+            ],
+          ]
+        );
+        return;
+      }
+      switch (sub[0]) {
+        case "init":
+          runInit(options);
+          break;
+
+        default:
+          break;
+      }
+
       console.log(name, sub);
-    }
+    },
+    ["add", "create", "initialize"]
   )
   .command("console", "Open the Blockless console in browser", () => {
     didRun = true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,8 +144,7 @@ args
       }
 
       console.log(name, sub);
-    },
-    ["add", "create", "initialize"]
+    }
   )
   .command("console", "Open the Blockless console in browser", () => {
     didRun = true;


### PR DESCRIPTION
This patch adds an `init` subcommand to the `bls function` subcommand.

```
bls function init --name my-bls-function --path ~/.bls/functions
```

The above command creates `path` and runs `npm init @blockless/app` in it, resulting in `~/.bls/functions/my-bls-function` containing a new starter Blockless app.