### PR TITLE
create .bls config dir and file

### DIFF
--- a/src/commands/login/index.ts
+++ b/src/commands/login/index.ts
@@ -2,7 +2,10 @@ import Fastify from "fastify";
 import { getDb } from "../../store/db";
 const portastic = require("portastic");
 
-const authHost = "http://console.bls.dev";
+const authHost =
+  process.env.NODE_ENV === "development"
+    ? "http://localhost"
+    : "http://console.bls.dev";
 const clientId = "7ddcb826-e84a-4102-b95b-d9b8d3a57176";
 
 const fastify = Fastify({
@@ -93,7 +96,10 @@ fastify.get("/complete", async (request: any, reply: any) => {
 const start = async () => {
   try {
     const ports = await portastic.find({ min: 8000, max: 8999 });
-    const port = ports[Math.floor(Math.random() * ports.length)];
+    const port =
+      process.env.NODE_ENV === "development"
+        ? 3000
+        : ports[Math.floor(Math.random() * ports.length)];
 
     // request a jwt from the console ui
     fastify.get("/", async (request, reply) => {

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -12,14 +12,12 @@ const cliConfigFileName = "bls.cli.config.json";
 const cliConfigFilePath = `${store.system.homedir}${store.system.appPath}`;
 const cliConfigFile = `${cliConfigFilePath}/${cliConfigFileName}`;
 
-const createConfigFile = () => {
-  if (!existsSync(cliConfigFile)) {
-    if (!existsSync(cliConfigFilePath)) {
-      execSync(`mkdir -p ${cliConfigFilePath}`);
-    }
-    writeFileSync(cliConfigFile, JSON.stringify({}));
+if (!existsSync(cliConfigFile)) {
+  if (!existsSync(cliConfigFilePath)) {
+    execSync(`mkdir -p ${cliConfigFilePath}`);
   }
-};
+  writeFileSync(cliConfigFile, JSON.stringify({}));
+}
 
 const adapter = new FileSync(cliConfigFile, {
   ...lowdbEncryption({

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -1,20 +1,32 @@
 // no types for this
 // @todo typings file for this
 import { store } from "./index";
+import { existsSync, writeFileSync } from "fs";
+import { execSync } from "child_process";
 
 const lowdb = require("lowdb");
 const FileSync = require("lowdb/adapters/FileSync");
 const lowdbEncryption = require("lowdb-encryption");
 
-const adapter = new FileSync(
-  `${store.system.homedir}${store.system.appPath}/bls.cli.config.json`,
-  {
-    ...lowdbEncryption({
-      secret: "s3cr3t",
-      iterations: 100_000,
-    }),
+const cliConfigFileName = "bls.cli.config.json";
+const cliConfigFilePath = `${store.system.homedir}${store.system.appPath}`;
+const cliConfigFile = `${cliConfigFilePath}/${cliConfigFileName}`;
+
+const createConfigFile = () => {
+  if (!existsSync(cliConfigFile)) {
+    if (!existsSync(cliConfigFilePath)) {
+      execSync(`mkdir -p ${cliConfigFilePath}`);
+    }
+    writeFileSync(cliConfigFile, JSON.stringify({}));
   }
-);
+};
+
+const adapter = new FileSync(cliConfigFile, {
+  ...lowdbEncryption({
+    secret: "s3cr3t",
+    iterations: 100_000,
+  }),
+});
 
 const db = lowdb(adapter);
 


### PR DESCRIPTION
This patch is a quick fix for a missing `~/.bls` directory or the configuration file and will create both filesystem objects