### PR TITLE
Feature/eng 102 bls function init should get a unique

### DIFF
--- a/src/commands/function/deploy.ts
+++ b/src/commands/function/deploy.ts
@@ -5,39 +5,8 @@ import { execSync } from "child_process";
 import FormData from "form-data";
 import { getConsoleServer, getTokenFromStore } from "../../lib/utils";
 import axios from "axios";
+import { IManifest } from "./interfaces";
 
-interface WasmMethod {
-  name: string;
-  entry: string;
-  result_type: string;
-}
-
-interface Manifest {
-  id: string;
-  name: string;
-  description: string;
-  fs_root_path: string;
-  limited_fuel?: number;
-  limited_memory?: number;
-  entry: string;
-  runtime: {
-    checksum: string;
-    url: string;
-  };
-  resources?: string[];
-  methods?: WasmMethod[];
-}
-
-const host =
-  process.env.NODE_ENV === "development"
-    ? "http://localhost:3005"
-    : "https://wasi.bls.dev";
-
-const getTokenFromStore = () => {
-  const db = getDb();
-  const { token } = db.get("config").value();
-  return token;
-};
 const consoleServer = getConsoleServer();
 
 const createChecksum = ({
@@ -56,9 +25,9 @@ const createManifest = (
   buildDir: string,
   entry: string,
   url: string
-): Manifest => {
+): IManifest => {
   const name = entry.split(".")[0];
-  const manifest: Manifest = {
+  const manifest: IManifest = {
     id: "",
     name,
     description: "",

--- a/src/commands/function/deploy.ts
+++ b/src/commands/function/deploy.ts
@@ -3,7 +3,7 @@ import { createHash, BinaryToTextEncoding } from "crypto";
 import Chalk from "chalk";
 import { execSync } from "child_process";
 import FormData from "form-data";
-import { getDb } from "../../store/db";
+import { getConsoleServer, getTokenFromStore } from "../../lib/utils";
 import axios from "axios";
 
 interface WasmMethod {
@@ -38,6 +38,7 @@ const getTokenFromStore = () => {
   const { token } = db.get("config").value();
   return token;
 };
+const consoleServer = getConsoleServer();
 
 const createChecksum = ({
   digest = "hex",
@@ -83,7 +84,7 @@ const deployWasm = async (manifest: any, archive: any, cb?: Function) => {
   formData.append("wasi_archive", archive);
 
   axios
-    .post(`${host}/api/modules/deploy`, formData, {
+    .post(`${consoleServer}/api/modules/deploy`, formData, {
       headers: {
         "Authorization": `Bearer ${token}`,
         "Content-Type": "multipart/form-data",

--- a/src/commands/function/init.ts
+++ b/src/commands/function/init.ts
@@ -1,17 +1,70 @@
 import Chalk from "chalk";
+import { store } from "../../store";
 import { execSync } from "child_process";
+import {
+  getConsoleServer,
+  getNpmConfigInitVersion,
+  getTokenFromStore,
+} from "../../lib/utils";
+import axios from "axios";
+import { IBlsFunction } from "./interfaces";
 
 const sanitizer = /[^a-zA-Z0-9\-]/;
 
 const sanitize = (input: string) => input.replace(sanitizer, "");
 
-export const run = (options: any) => {
-  const { name, path } = options;
-  const installationPath = `/${sanitize(path)}/${sanitize(name)}`;
+const consoleServer = getConsoleServer();
+const token = getTokenFromStore();
 
-  console.log(Chalk.yellow(`Initializing new function in ${installationPath}`));
+const saveNewFunction = (functionProps: IBlsFunction, cb?: Function) => {
+  const { functionId, name } = functionProps;
+  axios
+    .post(
+      `${consoleServer}/api/modules/new`,
+      {
+        functionId,
+        name,
+      },
+      {
+        headers: {
+          "Authorization": `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      }
+    )
+    .then((res) => {
+      if (cb) {
+        cb(res.data);
+      }
+    })
+    .catch((error) => {
+      console.log("error saving function", error);
+    });
+};
+
+export const run = (options: any) => {
+  const {
+    name,
+    path = `${store.system.homedir}/.bls`,
+    private: isPrivate,
+  } = options;
+  const installationPath = `/${sanitize(path)}/${sanitize(name)}`;
+  const version = getNpmConfigInitVersion();
+  const functionId = `blockless-function_${name}-${version}`; // TODO: standardize function  IDs
+
+  // initialize new local project
+  console.log(
+    Chalk.yellow(
+      `Initializing new function in ${installationPath} with ID ${functionId}`
+    )
+  );
+
   execSync(
-    `mkdir -p ${installationPath}; cd ${installationPath}; npm init @blockless/app`,
+    `mkdir -p ${installationPath};
+    cd ${installationPath};
+    npm init @blockless/app; npm pkg set name=${name} private=${Boolean(
+      isPrivate
+    ).toString()} "bls.functionId"=${functionId}`,
     {
       stdio: "inherit",
     }
@@ -21,4 +74,12 @@ export const run = (options: any) => {
       `Initialization of function ${installationPath} completed successfully`
     ) // because I said so in the absence of actual verification :D
   );
+
+  // upload new project
+  // check auth token validity; how?
+  // tbd
+  // if (token is valid) then
+  saveNewFunction({ functionId, name }, ({ _id }: any) => {
+    console.log(`Saved function in console successfully, id: ${_id}`);
+  });
 };

--- a/src/commands/function/interfaces.ts
+++ b/src/commands/function/interfaces.ts
@@ -1,0 +1,28 @@
+// Blocklesss interfaces
+export interface IBlsFunction {
+  functionId: string;
+  name: string;
+}
+
+// WASM interrfaces
+export interface IWasmMethod {
+  name: string;
+  entry: string;
+  result_type: string;
+}
+
+export interface IManifest {
+  id: string;
+  name: string;
+  description: string;
+  fs_root_path: string;
+  limited_fuel?: number;
+  limited_memory?: number;
+  entry: string;
+  runtime: {
+    checksum: string;
+    url: string;
+  };
+  resources?: string[];
+  methods?: IWasmMethod[];
+}

--- a/src/commands/login/index.ts
+++ b/src/commands/login/index.ts
@@ -1,11 +1,10 @@
 import Fastify from "fastify";
 import { getDb } from "../../store/db";
+import { getConsoleServer } from "../../lib/utils";
+
 const portastic = require("portastic");
 
-const authHost =
-  process.env.NODE_ENV === "development"
-    ? "http://localhost"
-    : "http://console.bls.dev";
+const consoleServer = getConsoleServer();
 const clientId = "7ddcb826-e84a-4102-b95b-d9b8d3a57176";
 
 const fastify = Fastify({
@@ -25,7 +24,7 @@ fastify.get("/token/:userId", async (request: any, reply: any) => {
     console.log("Error when attempting to login");
     return;
   }
-  console.log("User returned from https://console.bls.dev authenticated");
+  console.log(`User returned from ${consoleServer} authenticated`);
   reply.redirect("/complete");
 });
 
@@ -98,17 +97,18 @@ const start = async () => {
       process.env.NODE_ENV === "development"
         ? 3000
         : ports[Math.floor(Math.random() * ports.length)];
+    const localConsoleServer = getConsoleServer("local", port);
 
     // request a jwt from the console ui
     fastify.get("/", async (request, reply) => {
-      console.log("Sending user to https://console.bls.dev to authenticate");
+      console.log(`Sending user to ${consoleServer} to authenticate`);
       reply.redirect(
-        `${authHost}/login?returnUrl=http://localhost:${port}/token&clientId=${clientId}`
+        `${consoleServer}/login?returnUrl=${localConsoleServer}/token&clientId=${clientId}`
       );
     });
 
     fastify.listen({ port }).then(() => {
-      console.log(`Open Browser at http://localhost:${port} to complete login`);
+      console.log(`Open Browser at ${localConsoleServer} to complete login`);
     });
   } catch (err) {
     fastify.log.error(err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,11 +34,16 @@ function printHelp(commands: any = [], options: any = []) {
 
 args
   .options([
+    { name: "name", description: "The target name for the command" },
     {
       name: "path",
       description: "The target path for the command",
     },
-    { name: "name", description: "The target name for the command" },
+    {
+      name: "private",
+      description:
+        "For functions, setting this will mark the function as private",
+    },
   ])
   .command(
     "offchain",
@@ -144,15 +149,24 @@ args
               Chalk.red(`Missing required option ${Chalk.yellow("name")}\n`)
             );
             printHelp(
-              [["init", "initialize a new function with @blockless/app"]],
               [
                 [
-                  "-n, --name",
-                  "the name of the function to initialize (required)",
+                  "init",
+                  "Initialize a new function with @blockless/app and save it to Console.",
+                ],
+              ],
+              [
+                [
+                  "--name",
+                  "The name of the function to initialize.  This name will be used in the package's configuration file (i.e. package.json). (required)",
                 ],
                 [
-                  "-p, --path",
-                  `the location to initialize the function (optional; defaults to  ${store.system.homedir}/.bls)`,
+                  "--path",
+                  `The location to initialize the function (optional; defaults to  ${store.system.homedir}/.bls)`,
+                ],
+                [
+                  "--private",
+                  "If set, this function will not be made available for others to consume (optional; defaults to undefined)",
                 ],
               ]
             );
@@ -168,23 +182,21 @@ args
                 Chalk.red(`Missing required option ${Chalk.yellow(option)}\n`)
               );
               printHelp(
-                [["deploy", "deploy a function on Blockless"]],
+                [["deploy", "Deploy a function on Blockless"]],
                 [
+                  ["--name", "The name of the function to deploy (required)"],
                   [
-                    "-n, --name",
-                    "the name of the function to defploy (required)",
+                    "--path",
+                    "The location of the function' to deploy (required)",
+                  ],
+
+                  [
+                    "--rebuild",
+                    "Build the package before deploying it (optional; defaults to undefined)",
                   ],
                   [
-                    "-p, --path",
-                    "the location of the function to deploy (required)",
-                  ],
-                  [
-                    "-r, --rebuild",
-                    "build the package before deploying it (optional; defaults to undefined)",
-                  ],
-                  [
-                    "-d, --debug",
-                    "specifying the 'debug' option will build the debug version, otherwise the release version will be built (optional; defaults to undefined; only applicable if using the '--rebuild' option)",
+                    "--debug",
+                    "Specifying the 'debug' option will build the debug version, otherwise the release version will be built (optional; defaults to undefined; only applicable if using the '--rebuild' option)",
                   ],
                 ]
               );

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,26 @@
+import { execSync } from "child_process";
+import { readFileSync } from "fs";
+import { getDb } from "../store/db";
+
+// API Server
+export const getConsoleServer = (
+  location: "local" | "remote" = "remote",
+  port?: number
+) => {
+  const devMode = process.env.NODE_ENV === "development";
+  const local = location === "local";
+  const host = local ? "http://localhost" : "https://console.bls.dev";
+  return `${host}:${port ? port : devMode && local ? 3000 : 443}`;
+};
+
+// JWT retrieval
+
+export const getTokenFromStore = () => {
+  const db = getDb();
+  const { token } = db.get("config").value();
+  return token;
+};
+
+// Node/npm config
+export const getNpmConfigInitVersion = (): string =>
+  execSync("npm config get init-version").toString("utf-8");


### PR DESCRIPTION
This patch buffs the function init flow and provides a generated `fiunctionId` so that a call to the Console endpoint `/api/modules/new` can be made when a new function is initialized.  Sort of like registering it.