### PR TITLE
Fixes/re fix deploy pare down init

### DIFF
--- a/src/commands/function/deploy.ts
+++ b/src/commands/function/deploy.ts
@@ -9,6 +9,7 @@ import axios from "axios";
 import { IManifest } from "./interfaces";
 
 const consoleServer = getConsoleServer();
+const token = getToken();
 
 const createChecksum = ({
   digest = "hex",
@@ -43,12 +44,11 @@ const createManifest = (
 };
 
 const renameWasm = (path: string, oldName: string, newName: string) => {
-  execSync(`mv ${path}/${oldName} ${path}/${newName}`, { stdio: "inherit" });
+  execSync(`mv ${oldName} ${newName}`, { cwd: path, stdio: "inherit" });
 };
 
 const deployWasm = async (manifest: any, archive: any, cb?: Function) => {
   const formData = new FormData();
-  const token = await getToken();
 
   formData.append("manifest", manifest);
   formData.append("wasi_archive", archive);
@@ -56,7 +56,7 @@ const deployWasm = async (manifest: any, archive: any, cb?: Function) => {
   axios
     .post(`${consoleServer}/api/modules/deploy`, formData, {
       headers: {
-        Authorization: `Bearer ${token}`,
+        "Authorization": `Bearer ${token}`,
         "Content-Type": "multipart/form-data",
       },
     })
@@ -79,32 +79,38 @@ export const run = (options: any) => {
   const name = pathParts.pop();
   const wasmName = `${name}.wasm`;
   const wasmArchive = `${name}.tar.gz`;
-  const wasmManifest = createManifest(buildDir, wasmName, wasmArchive);
 
   if (rebuild) {
     console.log(Chalk.green(`Building function ${name} in ${buildDir}...`));
     execSync(
-      `cd ${path}; npm run build:${debug ? "debug" : "release"}; ${renameWasm(
+      `npm run build:${debug ? "debug" : "release"}; ${renameWasm(
         buildDir,
         defaultWasm,
         wasmName
       )}`,
-      {
-        stdio: "inherit",
-      }
+      { cwd: path, stdio: "inherit" }
     );
-  } else {
+  } else if (existsSync(`${buildDir}`)) {
     if (existsSync(`${buildDir}/${defaultWasm}`)) {
       renameWasm(buildDir, defaultWasm, wasmName);
     }
+  } else {
+    console.log(
+      Chalk.red(`Could not access ${buildDir}.  Has the function been built?`)
+    );
   }
+
   console.log(Chalk.yellow(`Creating tarball...`));
-  execSync(`cd ${buildDir}; tar zcf ${wasmArchive} ${wasmName}`, {
+  execSync(`tar zcf ${wasmArchive} ${wasmName}`, {
+    cwd: buildDir,
     stdio: "inherit",
   });
 
   console.log(Chalk.yellow(`Creating manifest...`));
-  writeFileSync(`${buildDir}/manifest.json`, JSON.stringify(wasmManifest));
+  writeFileSync(
+    `${buildDir}/manifest.json`,
+    JSON.stringify(createManifest(buildDir, wasmName, wasmArchive))
+  );
 
   console.log(Chalk.yellow(`Deploying function located in ${buildDir}`));
   deployWasm(

--- a/src/commands/function/init.ts
+++ b/src/commands/function/init.ts
@@ -1,43 +1,11 @@
 import Chalk from "chalk";
 import { store } from "../../store";
 import { execSync } from "child_process";
-import { getConsoleServer, getNpmConfigInitVersion } from "../../lib/utils";
-import { getToken } from "../../store/db";
-import axios from "axios";
-import { IBlsFunction } from "./interfaces";
+import { getNpmConfigInitVersion } from "../../lib/utils";
 
 const sanitizer = /[^a-zA-Z0-9\-]/;
 
 const sanitize = (input: string) => input.replace(sanitizer, "");
-
-const consoleServer = getConsoleServer();
-const token = getToken();
-
-const saveNewFunction = (functionProps: IBlsFunction, cb?: Function) => {
-  const { functionId, name } = functionProps;
-  axios
-    .post(
-      `${consoleServer}/api/modules/new`,
-      {
-        functionId,
-        name,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-      }
-    )
-    .then((res) => {
-      if (cb) {
-        cb(res.data);
-      }
-    })
-    .catch((error) => {
-      console.log("error saving function", error);
-    });
-};
 
 export const run = (options: any) => {
   const {
@@ -71,12 +39,4 @@ export const run = (options: any) => {
       `Initialization of function ${installationPath} completed successfully`
     ) // because I said so in the absence of actual verification :D
   );
-
-  // upload new project
-  // check auth token validity; how?
-  // tbd
-  // if (token is valid) then
-  saveNewFunction({ functionId, name }, ({ _id }: any) => {
-    console.log(`Saved function in console successfully, id: ${_id}`);
-  });
 };

--- a/src/commands/function/interfaces.ts
+++ b/src/commands/function/interfaces.ts
@@ -26,3 +26,9 @@ export interface IManifest {
   resources?: string[];
   methods?: IWasmMethod[];
 }
+
+export interface IDeploymentOptions {
+  functionId: string;
+  functionName: string;
+  userFunctionId: string;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,4 @@
 import { execSync } from "child_process";
-import { readFileSync } from "fs";
-import { getDb } from "../store/db";
 
 // API Server
 export const getConsoleServer = (


### PR DESCRIPTION
This patch clears up some of the confusion around "new" functions defined in the console UI and initializing a new _project_ in the cli with `function init` and then moves the deploy logic to `function deploy`.  Imagine that.

Also eliminates need for a specific `publish` command, I'll get a ticket start for that.