### PR TITLE
feature/eng-57-cli-function-init-should-update-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "portastic": "^1.0.1",
     "prompt": "^1.3.0",
     "readable-stream": "^4.1.0",
+    "replace-in-file": "^6.3.5",
     "ts-node": "^10.8.2",
     "typescript": "^4.7.4",
     "zlib": "^1.0.5"

--- a/src/commands/function/build.ts
+++ b/src/commands/function/build.ts
@@ -24,10 +24,6 @@ const createManifest = (
   return manifest;
 };
 
-const renameWasm = (path: string, oldName: string, newName: string) => {
-  execSync(`mv ${oldName} ${newName}`, { cwd: path, stdio: "inherit" });
-};
-
 export const run = (options: {
   debug: boolean;
   name: string;
@@ -36,15 +32,10 @@ export const run = (options: {
 }) => {
   const { debug, name, path, rebuild } = options;
   // check for and store unmodified wasm file name to change later
-  const defaultWasm = debug ? "debug.wasm" : "release.wasm";
   const buildDir = `${path}/build`;
-  const wasmName = `${name}.wasm`;
+  const wasmName = `${name}${debug ? "-debug" : ""}.wasm`;
   const wasmArchive = `${name}.tar.gz`;
-  const wasmManifest = createManifest(
-    buildDir,
-    debug ? `${buildDir}/${wasmName}` : wasmName,
-    wasmArchive
-  );
+  const wasmManifest = createManifest(buildDir, wasmName, wasmArchive);
 
   const build = () => {
     console.log(Chalk.green(`Building function ${name} in ${buildDir}...`));
@@ -52,10 +43,6 @@ export const run = (options: {
       cwd: path,
       stdio: "inherit",
     });
-
-    if (existsSync(`${buildDir}/${defaultWasm}`)) {
-      renameWasm(buildDir, defaultWasm, wasmName);
-    }
   };
 
   try {

--- a/src/commands/function/init.ts
+++ b/src/commands/function/init.ts
@@ -1,6 +1,7 @@
 import Chalk from "chalk";
 import { store } from "../../store";
 import { execSync } from "child_process";
+import replace from "replace-in-file";
 import { getNpmConfigInitVersion } from "../../lib/utils";
 
 const sanitizer = /[^a-zA-Z0-9\-]/;
@@ -17,6 +18,18 @@ export const run = (options: any) => {
   const version = getNpmConfigInitVersion();
   const functionId = `blockless-function_${name}-${version}`; // TODO: standardize function  IDs
 
+  //TODO: this is specific to asconfig.json, needs to be generalized for other scaffoldings
+  const replaceTargetOptions = {
+    files: `${installationPath}/asconfig.json`,
+    from: [/debug/g, /release/g],
+    to: [`${name}-debug`, name],
+  };
+
+  try {
+    replace.sync(replaceTargetOptions);
+  } catch (error) {
+    console.log(Chalk.red(`Could not replace build target strings: ${error}`));
+  }
   // initialize new local project
   console.log(
     Chalk.yellow(

--- a/src/commands/function/publish.ts
+++ b/src/commands/function/publish.ts
@@ -50,6 +50,7 @@ const logResult = (data: any) => {
 export const run = (options: any) => {
   const { debug, name, path, publishCallback = logResult, rebuild } = options;
   const buildDir = getBuildDir(path);
+  const wasmName = `${name}${debug ? "-debug" : ""}.wasm`;
   const wasmArchive = `${name}.tar.gz`;
   const {
     bls: { functionId: userFunctionId },
@@ -63,7 +64,7 @@ export const run = (options: any) => {
   }
 
   console.log(Chalk.yellow(`Creating tarball...`));
-  createWasmArchive(buildDir, wasmArchive, `${name}.wasm`);
+  createWasmArchive(buildDir, wasmArchive, wasmName);
 
   console.log(Chalk.yellow(`Deploying function located in ${buildDir}`));
   publishFunction(


### PR DESCRIPTION
This patch lets `init` deal with changing the build target output filenames/