### PR TITLE
Feature/eng 136 function init pathing

### DIFF
--- a/src/commands/function/deploy.ts
+++ b/src/commands/function/deploy.ts
@@ -9,6 +9,7 @@ const deploymentOptions: IDeploymentOptions = {
   functionName: "",
   userFunctionId: "",
 };
+const consoleServer = getConsoleServer();
 
 const server = "https://console.bls.dev";
 const token = getToken();

--- a/src/commands/function/deploy.ts
+++ b/src/commands/function/deploy.ts
@@ -9,8 +9,6 @@ const deploymentOptions: IDeploymentOptions = {
   functionName: "",
   userFunctionId: "",
 };
-const consoleServer = getConsoleServer();
-
 const server = "https://console.bls.dev";
 const token = getToken();
 

--- a/src/commands/function/index.ts
+++ b/src/commands/function/index.ts
@@ -4,3 +4,4 @@ export { run as runInit } from "./init";
 export { run as runInvoke } from "./invoke";
 export { run as runList } from "./list";
 export { run as runPublish } from "./publish";
+export { run as runUpdate } from "./update";

--- a/src/commands/function/init.ts
+++ b/src/commands/function/init.ts
@@ -5,8 +5,10 @@ import replace from "replace-in-file";
 import { getNpmConfigInitVersion } from "../../lib/utils";
 
 const sanitizer = /[^a-zA-Z0-9\-\.]/;
+const trailingSlash = /\/$/;
 
-const sanitize = (input: string) => input.replace(sanitizer, "");
+const sanitize = (input: string) =>
+  input.replace(sanitizer, "").replace(trailingSlash, "");
 
 export const run = (options: any) => {
   const { name, path = ".", private: isPrivate } = options;

--- a/src/commands/function/init.ts
+++ b/src/commands/function/init.ts
@@ -19,7 +19,7 @@ export const run = (options: any) => {
   //TODO: this is specific to asconfig.json, needs to be generalized for other scaffoldings
   const replaceTargetOptions = {
     files: `${installationPath}/asconfig.json`,
-    from: [/debug/g, /release/g],
+    from: [/build\/(debug)/g, /build\/(release)/g],
     to: [`${name}-debug`, name],
   };
 

--- a/src/commands/function/init.ts
+++ b/src/commands/function/init.ts
@@ -4,7 +4,7 @@ import replace from "replace-in-file";
 import { getNpmConfigInitVersion } from "../../lib/utils";
 import { removeTrailingSlash } from "./shared";
 
-const sanitizer = /[^a-zA-Z0-9\-\.]/;
+const sanitizer = /[^a-zA-Z0-9\-\.\/\~]/;
 
 const sanitize = (input: string) =>
   removeTrailingSlash(input.replace(sanitizer, ""));

--- a/src/commands/function/init.ts
+++ b/src/commands/function/init.ts
@@ -10,6 +10,15 @@ const trailingSlash = /\/$/;
 const sanitize = (input: string) =>
   input.replace(sanitizer, "").replace(trailingSlash, "");
 
+const renameBuildTargets = (replacementOptions: any) => {
+  console.log(Chalk.yellow("Renaming build targets"));
+  try {
+    replace.sync(replacementOptions);
+  } catch (error) {
+    console.log(Chalk.red(`Could not rename build targets: ${error}`));
+  }
+};
+
 export const run = (options: any) => {
   const { name, path = ".", private: isPrivate } = options;
   const installationPath = `${sanitize(path)}/${sanitize(name)}`;
@@ -23,11 +32,6 @@ export const run = (options: any) => {
     to: [`${name}-debug`, name],
   };
 
-  try {
-    replace.sync(replaceTargetOptions);
-  } catch (error) {
-    console.log(Chalk.red(`Could not replace build target strings: ${error}`));
-  }
   // initialize new local project
   console.log(
     Chalk.yellow(
@@ -45,6 +49,7 @@ export const run = (options: any) => {
       stdio: "inherit",
     }
   );
+  renameBuildTargets(replaceTargetOptions);
   console.log(
     Chalk.green(
       `Initialization of function ${installationPath} completed successfully`

--- a/src/commands/function/init.ts
+++ b/src/commands/function/init.ts
@@ -4,17 +4,13 @@ import { execSync } from "child_process";
 import replace from "replace-in-file";
 import { getNpmConfigInitVersion } from "../../lib/utils";
 
-const sanitizer = /[^a-zA-Z0-9\-]/;
+const sanitizer = /[^a-zA-Z0-9\-\.]/;
 
 const sanitize = (input: string) => input.replace(sanitizer, "");
 
 export const run = (options: any) => {
-  const {
-    name,
-    path = `${store.system.homedir}/.bls`,
-    private: isPrivate,
-  } = options;
-  const installationPath = `/${sanitize(path)}/${sanitize(name)}`;
+  const { name, path = ".", private: isPrivate } = options;
+  const installationPath = `${sanitize(path)}/${sanitize(name)}`;
   const version = getNpmConfigInitVersion();
   const functionId = `blockless-function_${name}-${version}`; // TODO: standardize function  IDs
 

--- a/src/commands/function/init.ts
+++ b/src/commands/function/init.ts
@@ -1,14 +1,13 @@
 import Chalk from "chalk";
-import { store } from "../../store";
 import { execSync } from "child_process";
 import replace from "replace-in-file";
 import { getNpmConfigInitVersion } from "../../lib/utils";
+import { removeTrailingSlash } from "./shared";
 
 const sanitizer = /[^a-zA-Z0-9\-\.]/;
-const trailingSlash = /\/$/;
 
 const sanitize = (input: string) =>
-  input.replace(sanitizer, "").replace(trailingSlash, "");
+  removeTrailingSlash(input.replace(sanitizer, ""));
 
 const renameBuildTargets = (replacementOptions: any) => {
   console.log(Chalk.yellow("Renaming build targets"));

--- a/src/commands/function/interfaces.ts
+++ b/src/commands/function/interfaces.ts
@@ -3,6 +3,12 @@ export interface IBlsFunction {
   functionId: string;
   name: string;
 }
+export interface IBlsFunctionRequiredOptions {
+  init: string[];
+  deploy: string[];
+  publish: string[];
+  update: string[];
+}
 
 // WASM interrfaces
 export interface IWasmMethod {

--- a/src/commands/function/shared.ts
+++ b/src/commands/function/shared.ts
@@ -14,3 +14,6 @@ export const createWasmArchive = (
   });
   return readFileSync(`${path}/${wasmArchive}`);
 };
+
+export const removeTrailingSlash = (input: string): string =>
+  input.replace(/\/$/, "");

--- a/src/commands/function/update.ts
+++ b/src/commands/function/update.ts
@@ -1,0 +1,3 @@
+import { run as runPublish } from "./publish";
+
+export const run = (options: any) => runPublish(options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,9 @@ import {
   runList,
   runPublish,
 } from "./commands/function";
+import {
+  IBlsFunctionRequiredOptions,
+} from "./commands/function/interfaces";
 import { run as runLogin } from "./commands/login";
 import { run as runInfo } from "./commands/info";
 
@@ -107,12 +110,7 @@ args
     "function",
     "Interact with Functions [init, invoke, delete, deploy, list]",
     (name: string, sub: string[], options) => {
-      interface RequiredOptions {
-        init: string[];
-        deploy: string[];
-        publish: string[];
-      }
-      const requiredOptions: RequiredOptions = {
+      const requiredOptions: IBlsFunctionRequiredOptions = {
         init: ["name"],
         deploy: ["name", "path"],
         publish: ["name", "path"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,6 @@ args
         deploy: ["name", "path"],
         publish: ["name", "path"],
       };
-      const index: keyof RequiredOptions = "init";
       didRun = true;
       if (!sub[0] || sub[0] === "help") {
         printHelp([

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,17 +120,14 @@ args
         printHelp([
           [
             "init\t",
-            "initialize a new function with blockless starter template",
+            "Initialize a new function with blockless starter template.",
           ],
-          ["deploy\t", "deploy a function on Blockless"],
+          ["deploy\t", "Deploy a function on Blockless."],
           [
             "list\t",
             "Retrieve a list of funtions deployed at Blockless Console.",
           ],
-          [
-            "invoke\t",
-            "Invokes the a function at the current (cwd) directory.",
-          ],
+          ["invoke\t", "Invokes the function at the current (cwd) directory."],
         ]);
         return;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   runInvoke,
   runList,
   runPublish,
+  runUpdate,
 } from "./commands/function";
 import {
   IBlsFunctionRequiredOptions,
@@ -114,6 +115,7 @@ args
         init: ["name"],
         deploy: ["name", "path"],
         publish: ["name", "path"],
+        update: ["name", "path"],
       };
       didRun = true;
       if (!sub[0] || sub[0] === "help") {
@@ -128,6 +130,7 @@ args
             "Retrieve a list of funtions deployed at Blockless Console.",
           ],
           ["invoke\t", "Invokes the function at the current (cwd) directory."],
+          ["update\t", "Update an existing function on Blockless."],
         ]);
         return;
       }
@@ -228,6 +231,36 @@ args
             }
           }
           runPublish(options);
+          break;
+        case "update":
+          for (const option of requiredOptions[sub[0]]) {
+            if (!(option in options)) {
+              console.log(
+                Chalk.red(`Missing required option ${Chalk.yellow(option)}\n`)
+              );
+              printHelp(
+                [["update", "Update an existing function on Blockless"]],
+                [
+                  ["--name", "The name of the function to update (required)"],
+                  [
+                    "--path",
+                    "The location of the function' to update (required)",
+                  ],
+
+                  [
+                    "--rebuild",
+                    "Build the package before updating it (optional; defaults to undefined)",
+                  ],
+                  [
+                    "--debug",
+                    "Specifying the 'debug' option will build the debug version, otherwise the release version will be built (optional; defaults to undefined; only applicable if using the '--rebuild' option)",
+                  ],
+                ]
+              );
+              return;
+            }
+          }
+          runUpdate(options);
           break;
         case "invoke":
           runInvoke(options);


### PR DESCRIPTION
Function initialization now accepts relative paths, drops trailing slashes from provided installation path, assumes `cwd` as the installation path if not provided, and updates the build target strings in `asconfig.json` *after* it exists 🤡