### PR TITLE
fixes pathing for init

### DIFF
--- a/src/commands/function/init.ts
+++ b/src/commands/function/init.ts
@@ -3,18 +3,19 @@ import { store } from "../../store";
 import { execSync } from "child_process";
 import replace from "replace-in-file";
 import { getNpmConfigInitVersion } from "../../lib/utils";
+const { resolve } = require("path");
 
 const sanitizer = /[^a-zA-Z0-9\-]/;
 
 const sanitize = (input: string) => input.replace(sanitizer, "");
 
 export const run = (options: any) => {
-  const {
-    name,
-    path = `${store.system.homedir}/.bls`,
-    private: isPrivate,
-  } = options;
-  const installationPath = `/${sanitize(path)}/${sanitize(name)}`;
+  const { name, path = process.cwd(), private: isPrivate } = options;
+  const installationPath = resolve(
+    process.cwd(),
+    `${path}`,
+    sanitize(`${name}`)
+  );
   const version = getNpmConfigInitVersion();
   const functionId = `blockless-function_${name}-${version}`; // TODO: standardize function  IDs
 


### PR DESCRIPTION
this fixes pathing for init, sanitize is only used for the file name, nodejs `resolve` is used to give us a pathing component from the relative or absolute path provided in input.